### PR TITLE
adding dependent lib

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -36,6 +36,7 @@
          <header-file src="src/ios/Headers/IMRequestStatus.h"/>
          <header-file src="src/ios/Headers/IMSdk.h"/>
          <source-file src="src/ios/libInMobi-5.0.2.a" framework="true"/>
+         <framework src="libsqlite3.0.tbd" />
     </platform>
 
 </plugin>


### PR DESCRIPTION
InMobi docs state `libsqlite3.0.tbd` is required lib. From my tests builds were failing without this lib.